### PR TITLE
Add OAuth state verification to Google login

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -65,6 +65,13 @@ def auth_google():
 @auth_bp.route("/auth/google/callback")
 def auth_google_callback():
     """Handle Google OAuth callback."""
+    state = request.args.get("state")
+    if state != session.get("oauth_state"):
+        return render_template(
+            "auth.html", state="error", error="Invalid OAuth state."
+        )
+    session.pop("oauth_state", None)
+
     code = request.args.get("code")
     if not code:
         return render_template(

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -1,7 +1,9 @@
 """Authentication service with business logic."""
 
+import secrets
 import requests
 from urllib.parse import urlencode
+from flask import session
 from models.auth import (
     generate_verification_code,
     save_verification_code,
@@ -219,11 +221,14 @@ def unlink_discord_account(user_email):
 
 def get_google_auth_url():
     """Get Google OAuth authorization URL."""
+    state = secrets.token_urlsafe()
+    session["oauth_state"] = state
     return "https://accounts.google.com/o/oauth2/auth?" + urlencode(
         {
             "client_id": GOOGLE_CLIENT_ID,
             "redirect_uri": REDIRECT_URI,
             "response_type": "code",
             "scope": "email profile",
+            "state": state,
         }
     )


### PR DESCRIPTION
## Summary
- generate and store random state for Google OAuth
- validate state on callback to prevent CSRF

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892ff74e63c83269f20d06d30f5ee01