### PR TITLE
Ensure admin routes use require_admin decorator

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -7,7 +7,6 @@ from flask import (
     redirect,
     request,
     session,
-    url_for,
     jsonify,
 )
 
@@ -50,18 +49,15 @@ def require_admin(f):
 
 
 @admin_bp.route("/admin/")
+@require_admin
 def admin_redirect():
     return redirect("/admin")
 
 
 @admin_bp.route("/admin")
+@require_admin
 def admin_dashboard():
     """Admin dashboard - accessible to all admins."""
-    if "user_email" not in session:
-        return redirect(url_for("auth.auth_google"))
-
-    if not is_admin(session["user_email"]):
-        return redirect("/")
 
     # Get basic statistics
     conn = get_db_connection()
@@ -113,13 +109,9 @@ def admin_dashboard():
 
 
 @admin_bp.route("/admin/users")
+@require_admin
 def admin_users():
     """Admin users page - accessible to all admins."""
-    if "user_email" not in session:
-        return redirect(url_for("auth.auth_google"))
-
-    if not is_admin(session["user_email"]):
-        return redirect("/")
 
     # Get all users from database
     users_data = get_all_users()
@@ -143,26 +135,16 @@ def admin_users():
 
 
 @admin_bp.route("/admin/keys")
+@require_admin
 def admin_keys():
     """Admin API keys page - accessible to all admins."""
-    if "user_email" not in session:
-        return redirect(url_for("auth.auth_google"))
-
-    if not is_admin(session["user_email"]):
-        return redirect("/")
-
     return render_template("admin/keys.html")
 
 
 @admin_bp.route("/admin/update-user", methods=["POST"])
+@require_admin
 def update_user_route():
     """Update user data - accessible to all admins."""
-    if "user_email" not in session:
-        return jsonify({"success": False, "error": "Not authenticated"}), 401
-
-    if not is_admin(session["user_email"]):
-        return jsonify({"success": False, "error": "Unauthorized"}), 403
-
     try:
         email = request.form.get("email")
         if not email:

--- a/routes/event_admin.py
+++ b/routes/event_admin.py
@@ -3,10 +3,8 @@
 from flask import (
     Blueprint,
     render_template,
-    redirect,
     request,
     session,
-    url_for,
     jsonify,
 )
 from models.admin import is_admin
@@ -34,11 +32,6 @@ def require_admin(f):
 @require_admin
 def admin_events_list():
     """Admin page to list all events."""
-    if "user_email" not in session:
-        return redirect(url_for("auth.auth_google"))
-
-    if not is_admin(session["user_email"]):
-        return redirect("/")
 
     # Get all events
     events = get_all_events()
@@ -68,11 +61,6 @@ def admin_events_list():
 @require_admin
 def admin_event_detail(event_id):
     """Admin page to view registrations for a specific event."""
-    if "user_email" not in session:
-        return redirect(url_for("auth.auth_google"))
-
-    if not is_admin(session["user_email"]):
-        return redirect("/")
 
     # Validate event exists
     if not is_valid_event(event_id):
@@ -105,11 +93,6 @@ def admin_event_detail(event_id):
 @require_admin
 def admin_purge_data_page():
     """Admin page for purging temporary data."""
-    if "user_email" not in session:
-        return redirect(url_for("auth.auth_google"))
-
-    if not is_admin(session["user_email"]):
-        return redirect("/")
 
     # Get all events with temporary data
     events = get_all_events()
@@ -220,8 +203,6 @@ def admin_purge_data_execute():
 @require_admin
 def admin_export_event_data(event_id):
     """Export event registration data as JSON."""
-    if "user_email" not in session or not is_admin(session["user_email"]):
-        return jsonify({"success": False, "error": "Unauthorized"}), 403
 
     # Validate event exists
     if not is_valid_event(event_id):


### PR DESCRIPTION
## Summary
- protect admin-facing pages with `@require_admin` instead of inline checks
- remove redundant authentication logic from event admin handlers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892ff91c7888326857b298b8f9444a6