### PR TITLE
Validate update_user fields and drop unused helper

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -12,7 +12,7 @@ from flask import (
 )
 
 # CSRF exemption will be handled in app.py
-from models.user import get_all_users, update_user
+from models.user import get_all_users
 from models.api_key import (
     get_all_api_keys,
     create_api_key,

--- a/routes/api.py
+++ b/routes/api.py
@@ -549,7 +549,10 @@ def api_discord_complete_verification():
         # Update user with Discord ID
         from models.user import update_user
 
-        update_user(user["id"], discord_id=discord_id)
+        try:
+            update_user(user["id"], discord_id=discord_id)
+        except ValueError as e:
+            return jsonify({"success": False, "error": str(e)}), 400
 
         return (
             jsonify(

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -21,7 +21,6 @@ from services.auth_service import (
     unlink_discord_account,
 )
 from models.user import get_user_by_email, create_user, update_user
-from models.user import get_user_by_email
 from models.oauth_token import create_oauth_token
 from config import DEBUG_MODE
 from urllib.parse import unquote
@@ -388,13 +387,25 @@ def register():
     # Create or update user
     if user:
         # Update existing user
-        update_user(
-            user["id"],
-            legal_name=legal_name,
-            preferred_name=preferred_name or None,
-            pronouns=pronouns,
-            dob=dob,
-        )
+        try:
+            update_user(
+                user["id"],
+                legal_name=legal_name,
+                preferred_name=preferred_name or None,
+                pronouns=pronouns,
+                dob=dob,
+            )
+        except ValueError as e:
+            return render_template(
+                "register.html",
+                user_email=user_email,
+                user_name=user_name,
+                errors=[str(e)],
+                legal_name=legal_name,
+                preferred_name=preferred_name,
+                pronouns=pronouns,
+                dob=dob,
+            )
     else:
         # Create new user
         create_user(

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -122,7 +122,10 @@ def complete_discord_verification(token, user_email):
         return {"success": False, "error": "User not found"}
 
     # Update user with Discord ID
-    update_user(user["id"], discord_id=token_info["discord_id"])
+    try:
+        update_user(user["id"], discord_id=token_info["discord_id"])
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
 
     # Mark token as used
     mark_token_used(token)
@@ -203,7 +206,10 @@ def unlink_discord_account(user_email):
     role_removal_result = remove_all_event_roles(discord_id)
 
     # Update user record to remove Discord ID
-    update_user(user["id"], discord_id=None)
+    try:
+        update_user(user["id"], discord_id=None)
+    except ValueError as e:
+        return {"success": False, "error": str(e)}
 
     return {
         "success": True,

--- a/utils/database.py
+++ b/utils/database.py
@@ -61,28 +61,6 @@ def get_all_users():
     return users_data
 
 
-def update_user(user_id, **kwargs):
-    """Update user with given fields."""
-    conn = get_db_connection()
-
-    # Build update query dynamically
-    update_fields = []
-    update_values = []
-
-    for field, value in kwargs.items():
-        if field == "events" and isinstance(value, list):
-            value = json.dumps(value)
-        update_fields.append(f"{field} = ?")
-        update_values.append(value)
-
-    if update_fields:
-        update_values.append(user_id)
-        query = f"UPDATE users SET {', '.join(update_fields)} WHERE id = ?"
-        conn.execute(query, update_values)
-        conn.commit()
-
-    conn.close()
-
 
 def delete_user(user_id):
     """Delete user by ID."""


### PR DESCRIPTION
## Summary
- remove generic `update_user` helper that allowed unrestricted updates
- gracefully handle `update_user` field validation errors in auth and API flows

## Testing
- `pytest`
- `python -m py_compile routes/admin.py routes/api.py routes/auth.py services/auth_service.py utils/database.py`


------
https://chatgpt.com/codex/tasks/task_e_6892ff9b76a88326bca4f26dca820a11