### PR TITLE
Use secrets for verification utilities

### DIFF
--- a/models/auth.py
+++ b/models/auth.py
@@ -1,6 +1,6 @@
 """Authentication models and utilities."""
 
-import random
+import secrets
 import string
 import sqlite3
 from datetime import datetime, timedelta
@@ -8,11 +8,12 @@ from utils.database import get_db_connection
 
 def generate_verification_code(length=6):
     """Generate a random verification code."""
-    return "".join(random.choices(string.digits, k=length))
+    return "".join(secrets.choice(string.digits) for _ in range(length))
 
 def generate_verification_token(length=32):
     """Generate a random verification token for Discord verification."""
-    return "".join(random.choices(string.ascii_letters + string.digits, k=length))
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
 
 def save_verification_token(discord_id, discord_username, message_id=None):
     """Save verification token to database with expiration time (10 minutes)."""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,19 @@
+import os
+import string
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
+from models.auth import generate_verification_code, generate_verification_token
+
+
+def test_generate_verification_code_length_and_digits():
+    code = generate_verification_code()
+    assert len(code) == 6
+    assert all(c in string.digits for c in code)
+
+
+def test_generate_verification_token_length_and_alphabet():
+    token = generate_verification_token()
+    assert len(token) == 32
+    alphabet = string.ascii_letters + string.digits
+    assert all(c in alphabet for c in token)


### PR DESCRIPTION
## Summary
- Improve security of verification code and token generation by using the `secrets` module
- Add tests verifying generated strings' length and character set

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689304c9e6748326881430aa93e74e04